### PR TITLE
Truncate post excerpts on index page

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -11,7 +11,7 @@ layout: default
         <h2><a href="{{ post.url }}">{{ post.title }}</a></h2>
         <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: "%B %d, %Y" }}</time>
         {% if post.excerpt %}
-          <p>{{ post.excerpt }}</p>
+          <p>{{ post.excerpt | strip_html | truncatewords: 50 }}</p>
         {% endif %}
       </li>
     {% endfor %}


### PR DESCRIPTION
## Summary
- Cap excerpts at 50 words with `truncatewords` filter
- Strip HTML to fix nested `<p>` tags in excerpt rendering

## Test plan
- [ ] Verify index page shows consistent short summaries for all posts

🤖 Generated with [Claude Code](https://claude.com/claude-code)